### PR TITLE
BENTO-2661 Fix Participant Icon & Upgrade DMN Core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7442,8 +7442,8 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-model-navigator": {
-      "version": "1.3.0",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#01294b53a67009374dc04bc5ef8b2c7421431495",
+      "version": "1.4.0",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#ea0b4ffec31b0f6042e6d3f1c4e6568a6a9c01c0",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",


### PR DESCRIPTION
### Overview

This PR bumps the core DMN version to v1.4.0 which includes refactoring to fix the participant icon, among many other things.

For the full change list, refer to: https://github.com/CBIIT/Data-Model-Navigator/compare/01294b53a67009374dc04bc5ef8b2c7421431495..ea0b4ffec31b0f6042e6d3f1c4e6568a6a9c01c0

### Change Details (Specifics)

N/A

### Related Ticket(s)

BENTO-2661
BENTO-2658
