### PR TITLE
Upgrade DMN Core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7375,8 +7375,8 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-model-navigator": {
-      "version": "1.4.0",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#ea0b4ffec31b0f6042e6d3f1c4e6568a6a9c01c0",
+      "version": "1.8.0",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#e62423efa3d956c6931f13e56a2c0faac6ea3a76",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7375,8 +7375,8 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-model-navigator": {
-      "version": "1.8.0",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#e62423efa3d956c6931f13e56a2c0faac6ea3a76",
+      "version": "1.8.1",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#3991563f2d0603c7ca49c255765491328de51be8",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",

--- a/src/config/ModelNavigator.ts
+++ b/src/config/ModelNavigator.ts
@@ -23,6 +23,7 @@ export const baseConfiguration = {
  * Base configuration for the graph view
  */
 export const graphViewConfig = {
+  legend: {},
   canvas: {
     fit: {
       x: 0,

--- a/src/hooks/useBuildReduxStore.ts
+++ b/src/hooks/useBuildReduxStore.ts
@@ -183,7 +183,7 @@ const useBuildReduxStore = (): ReduxStoreResult => {
     if (datacommon?.configuration?.iconMap) {
       store.dispatch({
         type: "RECEIVE_ICON_MAP",
-        data: datacommon?.assets?.["model-navigator-config"]?.iconMap,
+        data: datacommon?.configuration?.iconMap,
       });
     }
 

--- a/src/hooks/useBuildReduxStore.ts
+++ b/src/hooks/useBuildReduxStore.ts
@@ -4,7 +4,10 @@ import {
   ddgraph,
   moduleReducers as submission,
   versionInfo,
+  changelogInfo,
+  iconMapInfo,
   getModelExploreData,
+  getChangelog,
 } from "data-model-navigator";
 import {
   baseConfiguration,
@@ -27,7 +30,7 @@ export type ReduxStoreResult = [
 ];
 
 const makeStore = (): Store => {
-  const reducers = { ddgraph, versionInfo, submission };
+  const reducers = { ddgraph, versionInfo, submission, changelogInfo, iconMapInfo };
   const newStore = createStore(combineReducers(reducers));
 
   // @ts-ignore
@@ -89,17 +92,22 @@ const useBuildReduxStore = (): ReduxStoreResult => {
     };
 
     const assets = buildAssetUrls(datacommon);
+
     const response = await getModelExploreData(...assets.model_files)?.catch((e) => {
       Logger.error(e);
       return null;
     });
+    const changelogMD = await getChangelog(assets?.changelog)?.catch((e) => {
+      Logger.error(e);
+      return null;
+    });
+
     if (!response?.data || !response?.version) {
       setStatus("error");
       return;
     }
 
-    const { /* cdeMap, */ data: dataList } = response;
-    const dictionary = dataList;
+    const { data: dictionary } = response;
 
     // if (cdeMap) {
     //   const cdeInfo: CDEInfo[] = Array.from(response.cdeMap.values());
@@ -161,6 +169,23 @@ const useBuildReduxStore = (): ReduxStoreResult => {
         graphViewConfig,
       },
     });
+
+    if (changelogMD) {
+      store.dispatch({
+        type: "RECEIVE_CHANGELOG_INFO",
+        data: {
+          changelogMD,
+          changelogTabName: "Version History",
+        },
+      });
+    }
+
+    if (datacommon?.configuration?.iconMap) {
+      store.dispatch({
+        type: "RECEIVE_ICON_MAP",
+        data: datacommon?.assets?.["model-navigator-config"]?.iconMap,
+      });
+    }
 
     // MVP-2 M2 NOTE: This resets the search history to prevent the data models
     // from overlapping on searches. A future improvement would be to isolate

--- a/src/types/DataModelNavigator.d.ts
+++ b/src/types/DataModelNavigator.d.ts
@@ -49,6 +49,17 @@ type ModelNavigatorConfig = {
       nodeTree?: unknown;
     };
   };
+  /**
+   * A map of MDF category names to icon names.
+   *
+   * @example
+   * {
+   *   "mock-category": "case",
+   * }
+   */
+  iconMap?: {
+    [category: string]: string;
+  };
 };
 
 /**
@@ -78,6 +89,11 @@ type ModelAssetUrls = {
    * @since 3.1.0
    */
   navigator_icon: string;
+  /**
+   * the URL to the Data Model Release Notes file
+   * If this is null, the Release Notes tab will not be displayed
+   */
+  changelog?: string;
 };
 
 type FacetSearchData = {

--- a/src/utils/dataModelUtils.ts
+++ b/src/utils/dataModelUtils.ts
@@ -35,6 +35,9 @@ export const buildAssetUrls = (dc: DataCommon): ModelAssetUrls => ({
   navigator_icon: dc?.assets?.["model-navigator-logo"]
     ? `${dc?.assets["path"]}/${dc?.assets?.["model-navigator-logo"]}`
     : GenericModelLogo,
+  changelog: dc?.assets?.["release-notes"]
+    ? `${dc?.assets["path"]}/${dc?.assets?.["release-notes"]}`
+    : null,
 });
 
 /**


### PR DESCRIPTION
### Overview

Upgrade Model Navigator Core to v1.8.1, which brings all working changes from CRDC-DH into the standalone deployment.

### Change Details (Specifics)

- https://github.com/CBIIT/Data-Model-Navigator/compare/ea0b4ffec31b0f6042e6d3f1c4e6568a6a9c01c0..3991563f2d0603c7ca49c255765491328de51be8

### Related Ticket(s)

N/A
