### PR TITLE
1.2.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project provides a standalone version of the Data Model Navigator (DMN) pac
 
 |Tier|URL|Release Version|Core Version|
 |:-|:-|:-|:-|
-|DEV|https://dp2mdhy99qjlv.cloudfront.net/|1.2.0|v1.10.0|
+|DEV|https://dp2mdhy99qjlv.cloudfront.net/|1.2.0|v1.11.0|
 |PROD|https://d1bxc1yd643e0n.cloudfront.net/|1.1.0|v1.8.1|
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project provides a standalone version of the Data Model Navigator (DMN) pac
 
 |Tier|URL|Release Version|Core Version|
 |:-|:-|:-|:-|
-|DEV|https://dp2mdhy99qjlv.cloudfront.net/|1.1.0|v1.8.1|
+|DEV|https://dp2mdhy99qjlv.cloudfront.net/|1.2.0|v1.10.0|
 |PROD|https://d1bxc1yd643e0n.cloudfront.net/|1.1.0|v1.8.1|
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project provides a standalone version of the Data Model Navigator (DMN) pac
 |Tier|URL|Release Version|Core Version|
 |:-|:-|:-|:-|
 |DEV|https://dp2mdhy99qjlv.cloudfront.net/|1.2.0|v1.11.0|
-|PROD|https://d1bxc1yd643e0n.cloudfront.net/|1.1.0|v1.8.1|
+|PROD|https://d1bxc1yd643e0n.cloudfront.net/|1.2.0|v1.11.0|
 
 ## Installation
 

--- a/model_navigator_iframe_integration.md
+++ b/model_navigator_iframe_integration.md
@@ -73,6 +73,7 @@ my-organization/repository-xyz
     "name": "Mock MDF",
     "configuration": {
       "pageTitle": "Mock MDF Data Model",
+      "readMeDownload": false,
       "pdfConfig": {
         "fileType": "pdf",
         "prefix": "mock_",

--- a/model_navigator_iframe_integration.md
+++ b/model_navigator_iframe_integration.md
@@ -82,7 +82,8 @@ my-organization/repository-xyz
         "iconSrc": "https://pdf-header-logo-here/x.png",
         "footnote": "Example Footer Note",
         "landscape": true,
-        "enabled": true
+        "enabled": true,
+        "useTimestampInFilename": true
       }
     }
   }
@@ -93,13 +94,13 @@ my-organization/repository-xyz
 
 ## Embedding the Iframe
 
-**Base URL:**  
+**Base DEV URL:**  
 ```
-https://cbiit.github.io/crdc-data-model-navigator
+https://dp2mdhy99qjlv.cloudfront.net/
 ```
 Append `config` URL parameter, e.g.:  
 ```
-https://cbiit.github.io/crdc-data-model-navigator/?config=https://raw.githubusercontent.com/CBIIT/your-repository
+https://dp2mdhy99qjlv.cloudfront.net?config=https://raw.githubusercontent.com/CBIIT/your-repository
 ```
 
 ### Required Sandbox Attributes

--- a/package-lock.json
+++ b/package-lock.json
@@ -7375,8 +7375,8 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-model-navigator": {
-      "version": "1.9.5",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#ab9fddb7f271c99f87edb00fd4feedba4b515b73",
+      "version": "1.11.0",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#f145f800dc9da987b196d11e48878ef6a25a80c8",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7375,8 +7375,8 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-model-navigator": {
-      "version": "1.8.1",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#3991563f2d0603c7ca49c255765491328de51be8",
+      "version": "1.9.5",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#ab9fddb7f271c99f87edb00fd4feedba4b515b73",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",
@@ -7394,7 +7394,7 @@
         "js-yaml": "^3.13.1",
         "jszip": "^3.10.1",
         "lodash": "^4.17.20",
-        "marked": "^4.2.3",
+        "marked": "^17.0.4",
         "prop-types": "^15.7.2",
         "react-markdown": "^8.0.3",
         "react-redux": "^7.2.1",
@@ -13037,13 +13037,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.3.0",
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.4.tgz",
+      "integrity": "sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 20"
       }
     },
     "node_modules/mdast-util-definitions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crdc-data-model-navigator",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crdc-data-model-navigator",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@apollo/client": "^3.9.8",
         "@axe-core/react": "^4.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crdc-data-model-navigator",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "dependencies": {
     "@apollo/client": "^3.9.8",
     "@axe-core/react": "^4.9.0",

--- a/src/hooks/useBuildReduxStore.ts
+++ b/src/hooks/useBuildReduxStore.ts
@@ -159,7 +159,7 @@ const useBuildReduxStore = (): ReduxStoreResult => {
         readMeConfig: {
           readMeUrl: assets.readme,
           readMeTitle: datacommon.configuration?.readMeTitle || defaultReadMeTitle,
-          allowDownload: false,
+          allowDownload: datacommon.configuration?.readMeDownload || false,
         },
         pdfDownloadConfig: datacommon.configuration.pdfConfig,
         loadingExampleConfig: {

--- a/src/types/DataModelNavigator.d.ts
+++ b/src/types/DataModelNavigator.d.ts
@@ -16,6 +16,10 @@ type ModelNavigatorConfig = {
    * @default "Understanding the Data Model"
    */
   readMeTitle?: string;
+  /**
+   * Whether to show the README download button in the README modal popup
+   */
+  readMeDownload?: boolean;
   pdfConfig?: {
     [key: string]: unknown;
     /**


### PR DESCRIPTION
### Overview

This PR releases v1.2.0 of CRDC Model Navigator (standalone), which includes a bumped core DMN version and some QoL documentation updates.

### Change Details (Specifics)

N/A

### Related Ticket(s)

N/A
